### PR TITLE
Fix Vercel deployment issues by updating configurations and path aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
-dist
+# dist
 dist-ssr
 *.local

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-dist
+# dist
 dist-ssr
 *.local
 

--- a/backend/dist/backend/config/cache.js
+++ b/backend/dist/backend/config/cache.js
@@ -1,0 +1,19 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.TTL = exports.cache = void 0;
+const node_cache_1 = __importDefault(require("node-cache"));
+// TTL in seconds
+const TTL = {
+    EVENTS: 300, // 5 mins
+    ACTIVITIES: 60, // 1 min
+    USER_DATA: 1800, // 30 mins
+};
+exports.TTL = TTL;
+const cache = new node_cache_1.default({
+    stdTTL: 60,
+    checkperiod: 120,
+});
+exports.cache = cache;

--- a/backend/dist/backend/config/firebase.js
+++ b/backend/dist/backend/config/firebase.js
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const app_1 = require("firebase-admin/app");
+const firestore_1 = require("firebase-admin/firestore");
+const serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_KEY);
+(0, app_1.initializeApp)({
+    credential: (0, app_1.cert)(serviceAccount),
+});
+const db = (0, firestore_1.getFirestore)();
+db.settings({ ignoreUndefinedProperties: true });
+exports.default = db;

--- a/backend/dist/backend/index.js
+++ b/backend/dist/backend/index.js
@@ -1,12 +1,22 @@
 "use strict";
-try{
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-// import 'module-alias/register';
+// Workaround for module-alias in vercel deployment.
+if (process.env.VERCEL == "1" || __filename.endsWith(".js")) {
+    const tsConfig = require("../../tsconfig.json");
+    // Manually append dirname to path aliases to turn them into absolute paths
+    const resolvedPaths = Object.entries(tsConfig.compilerOptions.paths).reduce((acc, [key, paths]) => {
+        acc[key] = paths.map((path) => (path.startsWith("./") || path.startsWith("../") ? __dirname + "/" + path : path));
+        return acc;
+    }, {});
+    require("tsconfig-paths").register({ baseUrl: ".", paths: resolvedPaths });
+}
+else {
+    require("module-alias/register");
+}
 require("dotenv/config");
-require("module-alias/register");
 const express_1 = __importDefault(require("express"));
 const cors_1 = __importDefault(require("cors"));
 const eventRoutes_1 = __importDefault(require("@routes/eventRoutes"));
@@ -24,7 +34,14 @@ app.use("/api", activityRoutes_1.default);
 app.use("/api/user", userRoutes_1.default);
 app.use("/api/admin", adminRoutes_1.default);
 const PORT = (process.env.PORT || 3000);
-app.listen(PORT, "0.0.0.0", () => console.log(`Api server running on port ${PORT}`));
-} catch (e) {
-    console.log(e);
-}
+app.listen(PORT, "0.0.0.0", () => {
+    const serverUrl = `http://localhost:${PORT}`;
+    console.log(`✅ API server running successfully!`);
+    console.log(`📡 Listening on port ${PORT} (${serverUrl})`);
+    console.log(`🚀 API endpoints available at ${serverUrl}/api`);
+    console.log(`📚 Routes loaded: events, activities, user, admin`);
+    console.log(`💻 Environment: ${process.env.NODE_ENV || 'development'}`);
+}).on('error', (err) => {
+    console.error(`❌ Failed to start server: ${err.message}`);
+    process.exit(1);
+});

--- a/backend/dist/backend/index.js
+++ b/backend/dist/backend/index.js
@@ -1,0 +1,30 @@
+"use strict";
+try{
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// import 'module-alias/register';
+require("dotenv/config");
+require("module-alias/register");
+const express_1 = __importDefault(require("express"));
+const cors_1 = __importDefault(require("cors"));
+const eventRoutes_1 = __importDefault(require("@routes/eventRoutes"));
+const activityRoutes_1 = __importDefault(require("@routes/activityRoutes"));
+const userRoutes_1 = __importDefault(require("@routes/userRoutes"));
+const adminRoutes_1 = __importDefault(require("@routes/adminRoutes"));
+const app = (0, express_1.default)();
+app.use((0, cors_1.default)());
+app.use(express_1.default.json());
+app.get("/api", (req, res) => {
+    res.send("API Server is running successfully!!");
+});
+app.use("/api", eventRoutes_1.default);
+app.use("/api", activityRoutes_1.default);
+app.use("/api/user", userRoutes_1.default);
+app.use("/api/admin", adminRoutes_1.default);
+const PORT = (process.env.PORT || 3000);
+app.listen(PORT, "0.0.0.0", () => console.log(`Api server running on port ${PORT}`));
+} catch (e) {
+    console.log(e);
+}

--- a/backend/dist/backend/middleware/auth.js
+++ b/backend/dist/backend/middleware/auth.js
@@ -1,0 +1,35 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.adminMiddleware = exports.authMiddleware = void 0;
+const authUtils_1 = require("@utils/authUtils");
+const constants_1 = require("@common/constants");
+/**
+ * @description Middleware to authenticate user based on JWT token.
+ * @returns {Object} - Returns error response if token is missing or invalid, otherwise calls next middleware.
+ */
+const authMiddleware = (req, res, next) => {
+    var _a;
+    const token = (_a = req.headers.authorization) === null || _a === void 0 ? void 0 : _a.split(' ')[1];
+    if (!token) {
+        return res.status(401).json({ message: 'No token provided' });
+    }
+    const decoded = (0, authUtils_1.verifyToken)(token);
+    if (!decoded) {
+        return res.status(401).json({ message: 'Invalid token' });
+    }
+    req.user = decoded;
+    next();
+};
+exports.authMiddleware = authMiddleware;
+/**
+ * @description Middleware to authorize user with admin role.
+ * @returns {Object} - Returns error response if user is not an admin, otherwise calls next middleware.
+ */
+const adminMiddleware = (req, res, next) => {
+    var _a;
+    if (((_a = req.user) === null || _a === void 0 ? void 0 : _a.role) !== constants_1.Role.ADMIN) {
+        return res.status(403).json({ message: 'Admin access required' });
+    }
+    next();
+};
+exports.adminMiddleware = adminMiddleware;

--- a/backend/dist/backend/routes/activityRoutes.js
+++ b/backend/dist/backend/routes/activityRoutes.js
@@ -1,0 +1,91 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = __importDefault(require("express"));
+const activities_1 = require("../services/activities");
+const router = express_1.default.Router();
+/**
+ * Activity Routes
+ */
+// Get all activities for an event
+router.get('/activities/:eventId', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const activities = yield (0, activities_1.getActivities)(req.params.eventId);
+        res.json(activities || []);
+    }
+    catch (error) {
+        console.error('Error fetching activities:', error);
+        res.status(500).json({ message: 'Error fetching activities' });
+    }
+}));
+// Get specific activity by ID
+router.get('/activities/:eventId/:activityId', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const activity = yield (0, activities_1.getActivityById)(req.params.eventId, req.params.activityId);
+        if (activity) {
+            res.json(activity);
+        }
+        else {
+            res.status(404).json({ message: 'Activity not found' });
+        }
+    }
+    catch (error) {
+        console.error('Error fetching activity:', error);
+        res.status(500).json({ message: 'Error fetching activity' });
+    }
+}));
+// Create new activity
+router.post('/activities/:eventId', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const newActivity = yield (0, activities_1.createActivity)(req.params.eventId, req.body);
+        res.status(201).json(newActivity);
+    }
+    catch (error) {
+        console.error('Error creating activity:', error);
+        res.status(500).json({ message: 'Error creating activity' });
+    }
+}));
+// Update activity
+router.patch('/activities/:eventId/:activityId', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const updatedActivity = yield (0, activities_1.updateActivity)(req.params.eventId, req.params.activityId, req.body);
+        if (updatedActivity) {
+            res.json(updatedActivity);
+        }
+        else {
+            res.status(404).json({ message: 'Activity not found' });
+        }
+    }
+    catch (error) {
+        console.error('Error updating activity:', error);
+        res.status(500).json({ message: 'Error updating activity' });
+    }
+}));
+// Delete activity
+router.delete('/activities/:eventId/:activityId', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const result = yield (0, activities_1.deleteActivity)(req.params.eventId, req.params.activityId);
+        if (result) {
+            res.json({ message: 'Activity successfully deleted' });
+        }
+        else {
+            res.status(404).json({ message: 'Activity not found' });
+        }
+    }
+    catch (error) {
+        console.error('Error deleting activity:', error);
+        res.status(500).json({ message: 'Error deleting activity' });
+    }
+}));
+exports.default = router;

--- a/backend/dist/backend/routes/adminRoutes.js
+++ b/backend/dist/backend/routes/adminRoutes.js
@@ -1,0 +1,42 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = __importDefault(require("express"));
+const constants_1 = require("@common/constants");
+const authUtils_1 = require("@utils/authUtils");
+const auth_1 = require("@services/auth");
+const router = express_1.default.Router();
+// Route to authenticate admin and generate jwt token
+router.post('/authenticate', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const { username, password } = req.body;
+        // TODO: implement proper function to authenticate user
+        const userdata = {
+            username,
+            role: constants_1.Role.ADMIN
+        };
+        const isAuthenticated = yield (0, auth_1.authenticateUser)(username, password);
+        if (isAuthenticated) {
+            const token = (0, authUtils_1.generateToken)(userdata, constants_1.Role.ADMIN);
+            res.json({ userData: userdata, token });
+        }
+        else {
+            res.status(401).send('Invalid credentials');
+        }
+    }
+    catch (e) {
+        res.status(500).send(`Login failed: ${e.message}`);
+    }
+}));
+exports.default = router;

--- a/backend/dist/backend/routes/eventRoutes.js
+++ b/backend/dist/backend/routes/eventRoutes.js
@@ -1,0 +1,84 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// filepath: y:\All-Projects\Jain-Events-Portal\backend\routes\eventRoutes.ts
+const express_1 = require("express");
+const events_1 = require("../services/events");
+const router = (0, express_1.Router)();
+/**
+ * Event Routes
+ */
+// Get all events
+router.get('/events', (_, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const events = yield (0, events_1.getEvents)();
+        res.json(events);
+    }
+    catch (error) {
+        console.error('Error fetching events:', error);
+        res.status(500).json({ message: 'Error fetching events', details: error });
+    }
+}));
+// Get event by ID
+router.get('/events/:eventId', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const event = yield (0, events_1.getEventById)(req.params.eventId);
+        if (event) {
+            res.json(event);
+        }
+        else {
+            res.status(404).json({ message: 'Event not found' });
+        }
+    }
+    catch (error) {
+        console.error('Error fetching event:', error);
+        res.status(500).json({ message: 'Error fetching event', details: error });
+    }
+}));
+// Create new event
+router.post('/events', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const newEvent = yield (0, events_1.createEvent)(req.body);
+        res.status(201).json(newEvent);
+    }
+    catch (error) {
+        console.error('Error creating event:', error);
+        res.status(500).json({ message: 'Error creating event', details: error });
+    }
+}));
+// Update event
+router.patch('/events/:eventId', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const updatedEvent = yield (0, events_1.updateEvent)(req.params.eventId, req.body);
+        res.json(updatedEvent);
+    }
+    catch (error) {
+        console.error('Error updating event:', error);
+        res.status(500).json({ message: 'Error updating event', details: JSON.stringify(error) });
+    }
+}));
+// Delete event
+router.delete('/events/:eventId', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const result = yield (0, events_1.deleteEvent)(req.params.eventId);
+        if (result) {
+            res.json({ message: 'Event successfully deleted' });
+        }
+        else {
+            res.status(404).json({ message: 'Event not found' });
+        }
+    }
+    catch (error) {
+        console.error('Error deleting event:', error);
+        res.status(500).json({ message: 'Error deleting event', details: error });
+    }
+}));
+exports.default = router;

--- a/backend/dist/backend/routes/userRoutes.js
+++ b/backend/dist/backend/routes/userRoutes.js
@@ -1,0 +1,41 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = __importDefault(require("express"));
+const constants_1 = require("@common/constants");
+const authUtils_1 = require("@utils/authUtils");
+const auth_1 = require("@services/auth");
+const router = express_1.default.Router();
+// Route to authenticate user and generate jwt token
+router.post('/authenticate', (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const { username, password } = req.body;
+        // TODO: implement proper function to authenticate user
+        const userdata = {
+            username,
+            role: constants_1.Role.USER
+        };
+        if (yield (0, auth_1.authenticateUser)(username, password)) {
+            const token = (0, authUtils_1.generateToken)(userdata, constants_1.Role.USER);
+            res.json({ userData: userdata, token });
+        }
+        else {
+            res.status(401).send('Invalid credentials');
+        }
+    }
+    catch (e) {
+        res.status(500).send(`Login failed: ${e.message}`);
+    }
+}));
+exports.default = router;

--- a/backend/dist/backend/services/activities.js
+++ b/backend/dist/backend/services/activities.js
@@ -1,0 +1,115 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.deleteActivity = exports.updateActivity = exports.createActivity = exports.getActivityById = exports.getActivities = void 0;
+const firebase_1 = __importDefault(require("@config/firebase"));
+const uuid_1 = require("uuid");
+const cache_1 = require("@config/cache");
+// Collection references
+const eventsCollection = firebase_1.default.collection('events');
+const activitiesCollection = (eventId) => eventsCollection.doc(eventId).collection('activities');
+/**
+ * Get all activities for an event
+ */
+const getActivities = (eventId) => __awaiter(void 0, void 0, void 0, function* () {
+    const cacheKey = `activities-${eventId}`;
+    const cachedActivities = cache_1.cache.get(cacheKey);
+    if (cachedActivities) {
+        console.log(`📦 Serving cached activities for event ${eventId}`);
+        return cachedActivities;
+    }
+    const snapshot = yield activitiesCollection(eventId).get();
+    const activities = snapshot.docs.map(doc => (Object.assign({ id: doc.id, eventId }, doc.data())));
+    cache_1.cache.set(cacheKey, activities, cache_1.TTL.ACTIVITIES);
+    return activities;
+});
+exports.getActivities = getActivities;
+/**
+ * Get specific activity by ID
+ */
+const getActivityById = (eventId, activityId) => __awaiter(void 0, void 0, void 0, function* () {
+    const cacheKey = `activities-${eventId}-${activityId}`;
+    const cachedActivity = cache_1.cache.get(cacheKey);
+    if (cachedActivity) {
+        console.log(`📦 Serving cached activity ${activityId}`);
+        return cachedActivity;
+    }
+    const doc = yield activitiesCollection(eventId).doc(activityId).get();
+    if (!doc.exists)
+        return null;
+    const activityData = Object.assign({ id: doc.id, eventId }, doc.data());
+    cache_1.cache.set(cacheKey, activityData, cache_1.TTL.ACTIVITIES);
+    return activityData;
+});
+exports.getActivityById = getActivityById;
+/**
+ * Create new activity for an event
+ */
+const createActivity = (eventId, activityData) => __awaiter(void 0, void 0, void 0, function* () {
+    const eventDoc = yield eventsCollection.doc(eventId).get();
+    if (!eventDoc.exists) {
+        throw new Error(`Event ${eventId} does not exist`);
+    }
+    const activityId = activityData.id || (0, uuid_1.v4)();
+    const activityDoc = activitiesCollection(eventId).doc(activityId);
+    const { id, eventId: _ } = activityData, dataToStore = __rest(activityData, ["id", "eventId"]);
+    if (dataToStore.date) {
+        dataToStore.date = dataToStore.date instanceof Date ?
+            dataToStore.date : new Date(dataToStore.date);
+    }
+    yield activityDoc.set(dataToStore);
+    return Object.assign({ id: activityId, eventId }, dataToStore);
+});
+exports.createActivity = createActivity;
+/**
+ * Update existing activity
+ */
+const updateActivity = (eventId, activityId, activityData) => __awaiter(void 0, void 0, void 0, function* () {
+    const activityDoc = activitiesCollection(eventId).doc(activityId);
+    const doc = yield activityDoc.get();
+    if (!doc.exists)
+        return null;
+    const { id, eventId: _ } = activityData, dataToUpdate = __rest(activityData, ["id", "eventId"]);
+    if (dataToUpdate.date) {
+        dataToUpdate.date = dataToUpdate.date instanceof Date ?
+            dataToUpdate.date : new Date(dataToUpdate.date);
+    }
+    yield activityDoc.update(dataToUpdate);
+    const updatedDoc = yield activityDoc.get();
+    return Object.assign({ id: activityId, eventId }, updatedDoc.data());
+});
+exports.updateActivity = updateActivity;
+/**
+ * Delete activity
+ */
+const deleteActivity = (eventId, activityId) => __awaiter(void 0, void 0, void 0, function* () {
+    const activityDoc = activitiesCollection(eventId).doc(activityId);
+    const doc = yield activityDoc.get();
+    if (!doc.exists)
+        return false;
+    yield activityDoc.delete();
+    return true;
+});
+exports.deleteActivity = deleteActivity;

--- a/backend/dist/backend/services/auth.js
+++ b/backend/dist/backend/services/auth.js
@@ -1,0 +1,23 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.authenticateUser = authenticateUser;
+function authenticateUser(username, password) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // In a real application, you would query a database to validate the username and password.
+        // This is a placeholder implementation that always returns true for demonstration purposes.
+        // Replace this with your actual authentication logic.
+        if (password === 'test') {
+            return true;
+        }
+        return false;
+    });
+}

--- a/backend/dist/backend/services/events.js
+++ b/backend/dist/backend/services/events.js
@@ -1,0 +1,100 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.deleteEvent = exports.updateEvent = exports.createEvent = exports.getEventById = exports.getEvents = void 0;
+const Event_1 = __importDefault(require("@common/models/Event"));
+const utils_1 = require("@common/utils");
+const cache_1 = require("@config/cache");
+const firebase_1 = __importDefault(require("@config/firebase"));
+// Collection references
+const eventsCollection = firebase_1.default.collection('events');
+/**
+ * Get all events
+ */
+const getEvents = () => __awaiter(void 0, void 0, void 0, function* () {
+    const cachedEvents = cache_1.cache.get("events");
+    if (cachedEvents) {
+        console.log(`📦 Serving cached events`);
+        return cachedEvents;
+    }
+    const snapshot = yield eventsCollection.get();
+    const events = (0, utils_1.parseEvents)(snapshot.docs.map(doc => doc.data()));
+    cache_1.cache.set("events", events, cache_1.TTL.EVENTS);
+    return events;
+});
+exports.getEvents = getEvents;
+/**
+ * Get event by ID
+ */
+const getEventById = (eventId) => __awaiter(void 0, void 0, void 0, function* () {
+    const cachedEvent = cache_1.cache.get(`events-${eventId}`);
+    if (cachedEvent) {
+        console.log(`📦 Serving cached event ${eventId}`);
+        return cachedEvent;
+    }
+    const doc = yield eventsCollection.doc(eventId).get();
+    if (!doc.exists)
+        return null;
+    const eventData = Event_1.default.parse(doc.data());
+    cache_1.cache.set(`events-${eventId}`, eventData, cache_1.TTL.EVENTS);
+    return eventData;
+});
+exports.getEventById = getEventById;
+/**
+ * Create new event
+ */
+const createEvent = (eventData) => __awaiter(void 0, void 0, void 0, function* () {
+    const event = Event_1.default.parse(eventData);
+    const eventDoc = eventsCollection.doc(event.id);
+    yield eventDoc.set(event.toJSON());
+    cache_1.cache.set(`events-${event.id}`, event, cache_1.TTL.EVENTS);
+    cache_1.cache.del("events");
+    return event;
+});
+exports.createEvent = createEvent;
+/**
+ * Update existing event
+ */
+const updateEvent = (eventId, eventData) => __awaiter(void 0, void 0, void 0, function* () {
+    const event = Event_1.default.parse(eventData);
+    const eventDoc = eventsCollection.doc(event.id);
+    yield eventDoc.update(event.toJSON());
+    cache_1.cache.set(`events-${eventId}`, event, cache_1.TTL.EVENTS);
+    cache_1.cache.del("events");
+    return event;
+});
+exports.updateEvent = updateEvent;
+/**
+ * Delete event
+ */
+const deleteEvent = (eventId) => __awaiter(void 0, void 0, void 0, function* () {
+    const eventDoc = eventsCollection.doc(eventId);
+    const doc = yield eventDoc.get();
+    if (!doc.exists)
+        return false;
+    // Delete all activities/subCollections first
+    const eventSubCollections = yield eventDoc.listCollections();
+    const batch = firebase_1.default.batch();
+    yield Promise.all(eventSubCollections.map((collection) => __awaiter(void 0, void 0, void 0, function* () {
+        const collectionDocs = yield collection.get();
+        collectionDocs.docs.forEach(doc => {
+            batch.delete(doc.ref);
+        });
+    })));
+    // Then delete the event itself
+    batch.delete(eventDoc);
+    yield batch.commit();
+    return true;
+});
+exports.deleteEvent = deleteEvent;

--- a/backend/dist/backend/utils/authUtils.js
+++ b/backend/dist/backend/utils/authUtils.js
@@ -1,0 +1,35 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.verifyToken = exports.generateToken = void 0;
+const jsonwebtoken_1 = __importDefault(require("jsonwebtoken"));
+const JWT_SECRET = process.env.JWT_SECRET;
+/**
+ * Generates a JSON Web Token (JWT) for user authentication
+ * @param {UserData} userData - The user data object containing the username
+ * @param {string} role - The role of the user
+ * @returns {string} A signed JWT containing the user information
+ */
+const generateToken = (userData, role) => {
+    return jsonwebtoken_1.default.sign({
+        username: userData.username,
+        role,
+    }, JWT_SECRET, { expiresIn: '24h' });
+};
+exports.generateToken = generateToken;
+/**
+ * Verifies a JSON Web Token (JWT)
+ * @param {string} token - The JWT token to verify
+ * @returns {JwtPayload | null} Decoded token payload if verification succeeds, null if verification fails
+ */
+const verifyToken = (token) => {
+    try {
+        return jsonwebtoken_1.default.verify(token, JWT_SECRET);
+    }
+    catch (error) {
+        return null;
+    }
+};
+exports.verifyToken = verifyToken;

--- a/backend/dist/common/constants.js
+++ b/backend/dist/common/constants.js
@@ -1,0 +1,123 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Gender = exports.Role = exports.EventType = void 0;
+var EventType;
+(function (EventType) {
+    EventType[EventType["GENERAL"] = 0] = "GENERAL";
+    EventType[EventType["SPORTS"] = 1000] = "SPORTS";
+    EventType[EventType["VOLLEYBALL"] = 1001] = "VOLLEYBALL";
+    EventType[EventType["FOOTBALL"] = 1002] = "FOOTBALL";
+    EventType[EventType["CRICKET"] = 1003] = "CRICKET";
+    EventType[EventType["CULTURAL"] = 2000] = "CULTURAL";
+    EventType[EventType["DANCE"] = 2001] = "DANCE";
+    EventType[EventType["SINGING"] = 2002] = "SINGING";
+    EventType[EventType["DJ"] = 2003] = "DJ";
+    EventType[EventType["TECH"] = 3000] = "TECH";
+    EventType[EventType["CODING"] = 3001] = "CODING";
+    EventType[EventType["HACKATHON"] = 3002] = "HACKATHON";
+    EventType[EventType["QUIZ"] = 3003] = "QUIZ";
+    EventType[EventType["WORKSHOP"] = 3004] = "WORKSHOP";
+})(EventType || (exports.EventType = EventType = {}));
+/*
+// Create a mapping of Events
+export const EventType = {
+    GENERAL: { id: 0, name: 'General' },
+    SPORTS: { id: 1000, name: 'Sports' },
+    CULTURAL: { id: 2000, name: 'Cultural' },
+    TECH: { id: 3000, name: 'Tech' },
+} as const;
+
+// Create a mapping of Activities
+export const ActivityType = {
+    GENERAL: { id: 0, name: 'General', event: EventType.GENERAL },
+
+    VOLLEYBALL: { id: 1001, name: 'Volleyball', event: EventType.SPORTS },
+    FOOTBALL: { id: 1002, name: 'Football', event: EventType.SPORTS },
+    CRICKET: { id: 1003, name: 'Cricket', event: EventType.SPORTS },
+
+    DANCE: { id: 2001, name: 'Dance', event: EventType.CULTURAL },
+    SINGING: { id: 2002, name: 'Singing', event: EventType.CULTURAL },
+    DJ: { id: 2003, name: 'DJ', event: EventType.CULTURAL },
+
+    CODING: { id: 3001, name: 'Coding', event: EventType.TECH },
+    HACKATHON: { id: 3002, name: 'Hackathon', event: EventType.TECH },
+    QUIZ: { id: 3003, name: 'Quiz', event: EventType.TECH },
+    WORKSHOP: { id: 3004, name: 'Workshop', event: EventType.TECH },
+} as const;
+
+
+type NewEventType = {
+    GENERAL: {
+        id: 0
+    },
+
+    SPORTS: {
+        id: 1000,
+        activity: {
+            VOLLEYBALL: 1001,
+            FOOTBALL: 1002,
+            CRICKET: 1003,
+        }
+    },
+    
+    CULTURAL: {
+        id: 2000,
+        activity: {
+            DANCE: 2001,
+            SINGING: 2002,
+            DJ: 2003,
+        }
+    },
+
+    TECH: {
+        id: 3000,
+        activity: {
+            CODING: 3001,
+            HACKATHON: 3002,
+            QUIZ: 3003,
+            WORKSHOP: 3004,
+        }
+    }
+}
+
+type NewEventType2 = {
+    GENERAL: {
+        id: 0
+    },
+
+    SPORTS: {
+        id: 1000,
+        VOLLEYBALL: 1001,
+        FOOTBALL: 1002,
+        CRICKET: 1003,
+    },
+
+    CULTURAL: {
+        id: 2000,
+        DANCE: 2001,
+        SINGING: 2002,
+        DJ: 2003,
+    },
+
+    TECH: {
+        id: 3000,
+        CODING: 3001,
+        HACKATHON: 3002,
+        QUIZ: 3003,
+        WORKSHOP: 3004,
+    }
+}
+*/
+var Role;
+(function (Role) {
+    Role["ADMIN"] = "admin";
+    Role["USER"] = "user";
+    Role["GUEST"] = "guest";
+    Role["MANAGER"] = "manager";
+})(Role || (exports.Role = Role = {}));
+var Gender;
+(function (Gender) {
+    Gender["MALE"] = "male";
+    Gender["FEMALE"] = "female";
+    Gender["OTHER"] = "other";
+})(Gender || (exports.Gender = Gender = {}));

--- a/backend/dist/common/models/Activity.js
+++ b/backend/dist/common/models/Activity.js
@@ -1,0 +1,31 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const Participant_1 = __importDefault(require("./Participant"));
+const constants_1 = require("../constants");
+const utils_1 = require("@common/utils");
+const models_1 = require("@common/models");
+class Activity {
+    constructor(id, name, participants, eventType) {
+        this.id = id;
+        this.name = name;
+        this.participants = participants;
+        this.eventType = eventType;
+    }
+    static parse(data) {
+        // Determine the type of activity based on eventType
+        switch ((0, utils_1.getBaseEventType)(data.eventType)) {
+            case constants_1.EventType.SPORTS:
+                return models_1.SportsActivity.parse(data);
+            case constants_1.EventType.CULTURAL:
+                return models_1.CulturalActivity.parse(data);
+            default:
+                // Default Activity parsing logic
+                const participants = data.participants.map((p) => Participant_1.default.parse(p));
+                return new Activity(data.activityId, data.name, participants, data.eventType);
+        }
+    }
+}
+exports.default = Activity;

--- a/backend/dist/common/models/Event.js
+++ b/backend/dist/common/models/Event.js
@@ -1,0 +1,71 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const constants_1 = require("@common/constants");
+class Event {
+    constructor(id, name, type, timings, description, venue, banner) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+        this.description = description;
+        this.venue = venue;
+        this.banner = banner;
+        // Convert Timestamp-like objects (from firestore) to Date
+        this.timings = timings.map((t) => {
+            // If already a Date object
+            if (t instanceof Date)
+                return t;
+            // If it's a seconds+nanoseconds format (Firestore serialized timestamp)
+            if (t && typeof t._seconds === "number" && typeof t._nanoseconds === "number") {
+                return new Date(t._seconds * 1000 + t._nanoseconds / 1000000);
+            }
+            return new Date(t);
+        });
+    }
+    static parse(data) {
+        return new Event(data.id || '', data.name || '', data.type || constants_1.EventType.GENERAL, data.timings || [], data.description || '', data.venue || '', data.banner || {});
+    }
+    toJSON() {
+        // If there are timings, ensure they're stored as Firestore timestamps
+        if (this.timings && Array.isArray(this.timings)) {
+            this.timings = this.timings.map((date) => (date instanceof Date ? date : new Date(date)));
+        }
+        return {
+            id: this.id,
+            name: this.name,
+            type: this.type,
+            timings: this.timings.map((t) => t.toISOString()),
+            description: this.description,
+            venue: this.venue,
+            banner: this.banner,
+        };
+    }
+    get time() {
+        return {
+            start: this.timings[0],
+            end: this.timings[this.timings.length - 1],
+        };
+    }
+    get duration() {
+        const start = this.time.start.getTime();
+        const end = this.time.end.getTime();
+        return end - start;
+    }
+    // Convert event image CSS string to object
+    get eventBannerStyles() {
+        if (!this.banner.customCss)
+            return {};
+        return this.banner.customCss
+            .split(";")
+            .filter(Boolean)
+            .reduce((styleObj, rule) => {
+            const [prop, value] = rule.split(":").map(s => s.trim());
+            if (prop && value) {
+                // Convert kebab-case to camelCase
+                const camelProp = prop.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+                styleObj[camelProp] = value;
+            }
+            return styleObj;
+        }, {});
+    }
+}
+exports.default = Event;

--- a/backend/dist/common/models/Participant.js
+++ b/backend/dist/common/models/Participant.js
@@ -1,0 +1,14 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class Participant {
+    constructor(usn, name, gender, event) {
+        this.usn = usn;
+        this.name = name;
+        this.gender = gender;
+        this.event = event;
+    }
+    static parse(data) {
+        return new Participant(data.usn, data.name, data.gender, data.event);
+    }
+}
+exports.default = Participant;

--- a/backend/dist/common/models/culturals/CulturalActivity.js
+++ b/backend/dist/common/models/culturals/CulturalActivity.js
@@ -1,0 +1,19 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const Activity_1 = __importDefault(require("../Activity"));
+const constants_1 = require("../../constants");
+const Participant_1 = __importDefault(require("../Participant"));
+class CulturalActivity extends Activity_1.default {
+    constructor(activityId, name, participants, performanceDetails) {
+        super(activityId, name, participants, constants_1.EventType.CULTURAL);
+        this.performanceDetails = performanceDetails;
+    }
+    static parse(data) {
+        const participants = data.participants.map((p) => Participant_1.default.parse(p));
+        return new CulturalActivity(data.activityId, data.name, participants, data.performanceDetails);
+    }
+}
+exports.default = CulturalActivity;

--- a/backend/dist/common/models/index.js
+++ b/backend/dist/common/models/index.js
@@ -1,0 +1,21 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.CulturalActivity = exports.SportsPlayer = exports.SportsActivity = exports.Participant = exports.Event = exports.Activity = void 0;
+// Export base models
+var Activity_1 = require("./Activity");
+Object.defineProperty(exports, "Activity", { enumerable: true, get: function () { return __importDefault(Activity_1).default; } });
+var Event_1 = require("./Event");
+Object.defineProperty(exports, "Event", { enumerable: true, get: function () { return __importDefault(Event_1).default; } });
+var Participant_1 = require("./Participant");
+Object.defineProperty(exports, "Participant", { enumerable: true, get: function () { return __importDefault(Participant_1).default; } });
+// Export sports models
+var SportsActivity_1 = require("./sports/SportsActivity");
+Object.defineProperty(exports, "SportsActivity", { enumerable: true, get: function () { return __importDefault(SportsActivity_1).default; } });
+var SportsParticipant_1 = require("./sports/SportsParticipant");
+Object.defineProperty(exports, "SportsPlayer", { enumerable: true, get: function () { return __importDefault(SportsParticipant_1).default; } });
+// Export culturals models
+var CulturalActivity_1 = require("./culturals/CulturalActivity");
+Object.defineProperty(exports, "CulturalActivity", { enumerable: true, get: function () { return __importDefault(CulturalActivity_1).default; } });

--- a/backend/dist/common/models/sports/SportsActivity.js
+++ b/backend/dist/common/models/sports/SportsActivity.js
@@ -1,0 +1,24 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const Activity_1 = __importDefault(require("../Activity"));
+const SportsParticipant_1 = __importDefault(require("./SportsParticipant"));
+class SportsActivity extends Activity_1.default {
+    constructor(id, name, participants, eventType) {
+        super(id, name, participants, eventType);
+        this.id = id;
+        this.name = name;
+        this.participants = participants;
+        this.eventType = eventType;
+    }
+    static parse(data) {
+        const participants = data.participants.map((p) => SportsParticipant_1.default.parse(p));
+        return new SportsActivity(data.id, data.name, participants, data.eventType);
+    }
+    getTotalParticipants() {
+        return this.participants.length;
+    }
+}
+exports.default = SportsActivity;

--- a/backend/dist/common/models/sports/SportsParticipant.js
+++ b/backend/dist/common/models/sports/SportsParticipant.js
@@ -1,0 +1,48 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const Participant_1 = __importDefault(require("../Participant"));
+class SportsPlayer extends Participant_1.default {
+    constructor(usn, name, gender, event, stats) {
+        // let event: EventType;
+        // switch (stats) {
+        //   case stats as Volleyball: event = EventType.VOLLEYBALL; break;
+        //   case stats as Football: event = EventType.FOOTBALL; break;
+        //   case stats as Cricket: event = EventType.CRICKET; break;
+        //   default: throw new Error("Invalid sport type");
+        // };
+        super(usn, name, gender, event);
+        this.stats = stats;
+    }
+    static parse(data) {
+        const s = super.parse(data);
+        const stats = data.stats;
+        return new SportsPlayer(s.usn, s.name, s.gender, s.event, stats);
+    }
+    getPlayerType() {
+        if ('points' in this.stats) {
+            return 'Volleyball Player';
+        }
+        else if ('position' in this.stats) {
+            return 'Football Player';
+        }
+        else if ('runs' in this.stats) {
+            return 'Cricket Player';
+        }
+        return 'Unknown Player Type';
+    }
+}
+exports.default = SportsPlayer;
+/*
+// Example usage:
+let volleyballPlayer = new SportsPlayer<Volleyball>('1MS17IS004', 'David', Gender.MALE, EventType.VOLLEYBALL, { points: 20, spikes: 15, blocks: 5 });
+console.log(volleyballPlayer.stats.spikes);
+
+let footballPlayer = new SportsPlayer<Football>('1MS17IS002', 'Bob', Gender.MALE, EventType.FOOTBALL, { position: 'Forward', goals: 20, assists: 10 });
+console.log(footballPlayer.stats.goals);
+
+let cricketPlayer = new SportsPlayer<Cricket>('1MS17IS001', 'Alice', Gender.FEMALE, EventType.CRICKET, { runs: 1000, wickets: 50 });
+console.log(cricketPlayer.stats.runs);
+*/ 

--- a/backend/dist/common/utils.js
+++ b/backend/dist/common/utils.js
@@ -1,0 +1,22 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getBaseEventType = void 0;
+exports.parseEvents = parseEvents;
+exports.parseActivities = parseActivities;
+const constants_1 = require("./constants");
+const models_1 = require("./models");
+function parseEvents(data) {
+    return data.map((it) => models_1.Event.parse(it));
+}
+function parseActivities(data) {
+    return data.map((it) => models_1.Activity.parse(it));
+}
+const getBaseEventType = (it) => {
+    if (it >= constants_1.EventType.CULTURAL)
+        return constants_1.EventType.CULTURAL;
+    else if (it >= constants_1.EventType.SPORTS)
+        return constants_1.EventType.SPORTS;
+    else
+        return constants_1.EventType.GENERAL;
+};
+exports.getBaseEventType = getBaseEventType;

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,13 +1,25 @@
-// import 'module-alias/register';
-import 'dotenv/config';
-import 'module-alias/register';
-import express, { Request, Response } from 'express';
-import cors from 'cors';
+// Workaround for module-alias in vercel deployment.
+if (process.env.VERCEL == "1" || __filename.endsWith(".js")) {
+	const tsConfig = require("../../tsconfig.json");
+    // Manually append dirname to path aliases to turn them into absolute paths
+	const resolvedPaths = Object.entries(tsConfig.compilerOptions.paths).reduce<Record<string, string[]>>((acc, [key, paths]) => {
+		acc[key] = (paths as string[]).map((path: string) => (path.startsWith("./") || path.startsWith("../") ? __dirname + "/" + path : path));
+		return acc;
+	}, {});
 
-import eventRoutes from '@routes/eventRoutes';
-import activityRoutes from '@routes/activityRoutes';
-import userRoutes from '@routes/userRoutes';
-import adminRoutes from '@routes/adminRoutes';
+	require("tsconfig-paths").register({ baseUrl: ".", paths: resolvedPaths });
+} else {
+	require("module-alias/register");
+}
+
+import "dotenv/config";
+import express, { Request, Response } from "express";
+import cors from "cors";
+
+import eventRoutes from "@routes/eventRoutes";
+import activityRoutes from "@routes/activityRoutes";
+import userRoutes from "@routes/userRoutes";
+import adminRoutes from "@routes/adminRoutes";
 
 const app = express();
 
@@ -15,7 +27,7 @@ app.use(cors<Request>());
 app.use(express.json());
 
 app.get("/api", (req: Request, res: Response) => {
-    res.send("API Server is running successfully!!");
+	res.send("API Server is running successfully!!");
 });
 
 app.use("/api", eventRoutes);
@@ -24,4 +36,14 @@ app.use("/api/user", userRoutes);
 app.use("/api/admin", adminRoutes);
 
 const PORT = (process.env.PORT || 3000) as number;
-app.listen(PORT, "0.0.0.0", () => console.log(`Api server running on port ${PORT}`));
+app.listen(PORT, "0.0.0.0", () => {
+    const serverUrl = `http://localhost:${PORT}`;
+    console.log(`✅ API server running successfully!`);
+    console.log(`📡 Listening on port ${PORT} (${serverUrl})`);
+    console.log(`🚀 API endpoints available at ${serverUrl}/api`);
+    console.log(`📚 Routes loaded: events, activities, user, admin`);
+    console.log(`💻 Environment: ${process.env.NODE_ENV || 'development'}`);
+}).on('error', (err) => {
+    console.error(`❌ Failed to start server: ${err.message}`);
+    process.exit(1);
+});

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -25,6 +25,7 @@
         "pre-commit": "^1.2.2",
         "rimraf": "^6.0.1",
         "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "^5.7.3"
       }
     },
@@ -2149,6 +2150,19 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -2433,6 +2447,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -3231,6 +3255,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strnum": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
@@ -3411,6 +3445,21 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,6 +22,8 @@
         "@types/express": "^5.0.0",
         "@types/node": "^22.13.5",
         "express": "^4.21.2",
+        "pre-commit": "^1.2.2",
+        "rimraf": "^6.0.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.3"
       }
@@ -245,6 +247,109 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -590,7 +695,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "optional": true,
+      "devOptional": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -599,7 +705,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "optional": true,
+      "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -748,7 +855,15 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -837,7 +952,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "optional": true,
+      "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -849,7 +965,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -866,7 +983,57 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -902,7 +1069,15 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -920,7 +1095,38 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -1005,6 +1211,13 @@
         "stream-shift": "^1.0.2"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -1023,7 +1236,8 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -1268,6 +1482,77 @@
         "@google-cloud/storage": "^7.14.0"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/form-data": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
@@ -1416,6 +1701,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -1425,6 +1734,32 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/google-auth-library": {
@@ -1732,7 +2067,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "optional": true,
+      "devOptional": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1765,6 +2101,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
+      "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jose": {
@@ -2069,6 +2435,16 @@
         "node": "*"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/module-alias": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
@@ -2233,6 +2609,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -2248,6 +2633,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2255,6 +2647,43 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2273,6 +2702,26 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pre-commit": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
+      "integrity": "sha512-qokTiqxD6GjODy5ETAIgzsRgnBWWQHQH2ghy86PU7mIn/wuWeTwF3otyNQZxWBwVn8XNr8Tdzj/QfUXpH+gRZA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^5.0.1",
+        "spawn-sync": "^1.0.15",
+        "which": "1.2.x"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
@@ -2322,6 +2771,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -2422,6 +2878,26 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/safe-buffer": {
@@ -2530,7 +3006,31 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -2604,6 +3104,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -2613,6 +3126,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
       }
     },
     "node_modules/statuses": {
@@ -2652,7 +3177,24 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "optional": true,
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2666,7 +3208,22 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "optional": true,
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -2874,6 +3431,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
@@ -2910,7 +3474,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -2982,11 +3547,43 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha512-16uPglFkRPzgiUXYMi1Jf8Z5EzN1iB4V0ZtMXcHZnwsBtQhhHeCqoWw7tsUY42hJGNDWtUsVLTjakIa5BgAxCw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,6 +39,7 @@
     "pre-commit": "^1.2.2",
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3"
   },
   "_moduleAliases": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,10 @@
   "description": "A events management portal for Jain Universtiy",
   "main": "index.ts",
   "scripts": {
+    "start": "nodemon ./index.ts",
+    "build": "rimraf dist && tsc",
+    "ts.check": "tsc --project tsconfig.json",
+    "add-build": "git add dist",
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "nodemon --exec npx ts-node ./index.ts",
     "debug": "nodemon --inspect --exec npx ts-node ./index.ts"
@@ -32,6 +36,8 @@
     "@types/express": "^5.0.0",
     "@types/node": "^22.13.5",
     "express": "^4.21.2",
+    "pre-commit": "^1.2.2",
+    "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3"
   },
@@ -42,5 +48,10 @@
     "@routes": "./routes",
     "@services": "./services",
     "@utils": "./utils"
-  }
+  },
+  "pre-commit": [
+    "ts.check",
+    "build",
+    "add-build"
+  ]
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -2,17 +2,20 @@
     "compilerOptions": {
         "target": "es6",
         "module": "commonjs",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "baseUrl": ".",
+        "outDir": "dist",
         "paths": {
             "@common/*": ["../common/*"],
             "@config/*": ["./config/*"],
             "@middlewares/*": ["./middlewares/*"],
             "@routes/*": ["./routes/*"],
             "@services/*": ["./services/*"],
-            "@utils/*": ["./utils/*"]
-        },
-        "strict": true,
-        "esModuleInterop": true,
-        "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true
+            "@utils/*": ["./utils/*"],
+            "*": ["node_modules/*", "types/*"]
+        }
     }
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -17,5 +17,7 @@
             "@utils/*": ["./utils/*"],
             "*": ["node_modules/*", "types/*"]
         }
-    }
+    },
+    "include": ["**/*"],
+    "exclude": ["node_modules"]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -26,7 +26,7 @@
     "routes": [
         {
             "src": "/api(/?.*)",
-            "dest": "/backend/dist/index.js"
+            "dest": "/backend/dist/backend/index.js"
         },
         {
             "src": "/admin/assets/(.*)",

--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,11 @@
     "version": 2,
     "builds": [
         {
-            "src": "backend/index.ts",
-            "use": "@vercel/node"
+            "src": "backend/dist/backend/index.js",
+            "use": "@vercel/node",
+            "config": { 
+                "includeFiles": ["./backend/dist/**"]
+            }
         },
         {
             "src": "clientview/package.json",
@@ -23,7 +26,7 @@
     "routes": [
         {
             "src": "/api(/?.*)",
-            "dest": "/backend/index.ts"
+            "dest": "/backend/dist/index.js"
         },
         {
             "src": "/admin/assets/(.*)",


### PR DESCRIPTION
I felt this needed a separate PR due to rather major changes it involves...

Getting the API running back again after the js-to-ts migration was a pain due to conflicting imports.

Vercel supports only js apps with node, so as a workaround for our ts based backen, we'll need to build and upload the /backend/dist directory directly to github.

So hereafter, every commit to the deployment branch should first run `npm run build` in /backend to generate /backend/dist.

As for what the workaround is- basically, prepended all module aliases with hardcoded paths.

Well, anyways, the rewritten site is finally up online here~!!
https://jain-events-portal.vercel.app/
https://jain-events-portal.vercel.app/admin